### PR TITLE
C deployment of the templates despite errors

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -21,6 +21,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Deploy Web API Template to AWS CloudFormation
+        continue-on-error: true
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           name: WebApiStack
@@ -34,6 +35,7 @@ jobs:
             AmiId=ami-09040d770ffe2224f
 
       - name: Deploy Web App Template to AWS CloudFormation
+        continue-on-error: true
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           name: WebAppStack


### PR DESCRIPTION
Deployment fails if there are no change-set to be submitted. So, we'd have to continue the workflow in case changes are made in the deployments coming after the failed one