### PR TITLE
Update the deploy cf action to not fail if the change set is empty

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -21,11 +21,11 @@ jobs:
           aws-region: us-east-2
 
       - name: Deploy Web API Template to AWS CloudFormation
-        continue-on-error: true
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           name: WebApiStack
           template: template-web-api.yaml
+          no-fail-on-empty-changeset: "1"
           parameter-overrides: >-
             AvailabilityZone=us-east-2a,
             KeyPairName=grimoire-key-pair,
@@ -35,11 +35,11 @@ jobs:
             AmiId=ami-09040d770ffe2224f
 
       - name: Deploy Web App Template to AWS CloudFormation
-        continue-on-error: true
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           name: WebAppStack
           template: template-web-app.yaml
+          no-fail-on-empty-changeset: "1"
           parameter-overrides: >-
             BucketName=grimoire-web-app-bucket,
             IndexDocument=index.html


### PR DESCRIPTION
Remove continue-on-error and make the Deploy CloudFormation action not fail in case there is no change set. This will make the workflow cleaner and transparent