### PR TITLE
Make the bucket publicly available

### DIFF
--- a/template-web-app.yaml
+++ b/template-web-app.yaml
@@ -11,6 +11,7 @@ Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
+      AccessControl: PublicRead
       BucketName: !Ref BucketName
       WebsiteConfiguration:
         IndexDocument: index.html


### PR DESCRIPTION
Set the AccessControl property to PublicRead, so that we would be able to attach the bucket policy to it